### PR TITLE
Update scala version for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 
 scala:
   #  - 2.10.6
-  - 2.11.7
+  - 2.11.8
 
 jdk:
   - oraclejdk7


### PR DESCRIPTION
I updated scala version to `2.11.8` from `2.11.7` for travis.
